### PR TITLE
update to parse_gct.py

### DIFF
--- a/cmapPy/pandasGEXpress/parse_gct.py
+++ b/cmapPy/pandasGEXpress/parse_gct.py
@@ -162,7 +162,7 @@ def parse(file_path, convert_neg_666=True, rid=None, cid=None,
 
 def read_version_and_dims(file_path):
     # Open file
-    f = open(file_path, "rb")
+    f = open(file_path, "r")
 
     # Get version from the first line
     version = f.readline().strip().lstrip("#")


### PR DESCRIPTION
changed open(file_path, "rb") rb flag to r. using rb creates a bytes-like object which then causes an  error at line 168 where f.readline().strip().lstrip('#') expects a string (Python 3.7).